### PR TITLE
use local zipfiles on vader

### DIFF
--- a/sushichef.py
+++ b/sushichef.py
@@ -400,7 +400,7 @@ PRADIGI_STRINGS = {
 def get_subtree_by_subject_en(lang, subject):
     if lang not in PRADIGI_LANG_URL_MAP:
         raise ValueError('Language `lang` must be in PRADIGI_LANG_URL_MAP')
-    wrt_filename = 'chefdata/trees/pradigi_{}_web_resource_tree.json'.format(lang)
+    wrt_filename = 'chefdata/vader/trees/pradigi_{}_web_resource_tree.json'.format(lang)
     with open(wrt_filename) as jsonfile:
         web_resource_tree = json.load(jsonfile)
     subject_subtrees = web_resource_tree['children']
@@ -425,7 +425,7 @@ def get_subtree_by_source_id(lang, source_id):
     """
     if lang not in PRADIGI_LANG_URL_MAP:
         raise ValueError('Language `lang` must be in PRADIGI_LANG_URL_MAP')
-    wrt_filename = 'chefdata/trees/pradigi_{}_web_resource_tree.json'.format(lang)
+    wrt_filename = 'chefdata/vader/trees/pradigi_{}_web_resource_tree.json'.format(lang)
     with open(wrt_filename) as jsonfile:
         web_resource_tree = json.load(jsonfile)
     # setup recusive find function
@@ -586,7 +586,7 @@ def find_games_for_lang(name, lang, take_from=None):
     language_en = PRADIGI_STRINGS[lang]['language_en'] # ???
 
     # load website game web resource data
-    WEBSITE_GAMES_OUTPUT = 'chefdata/trees/website_games_all_langs.json'
+    WEBSITE_GAMES_OUTPUT = 'chefdata/vader/trees/website_games_all_langs.json'
     website_data = json.load(open(WEBSITE_GAMES_OUTPUT, 'r'))
     if lang in website_data:
         website_data_lang = website_data[lang]
@@ -692,7 +692,7 @@ def extract_website_games_from_tree(lang):
     if lang not in PRADIGI_LANG_URL_MAP:
         raise ValueError('Language `lang` must be in PRADIGI_LANG_URL_MAP')
     # READ IN
-    wrt_filename = 'chefdata/trees/pradigi_{}_web_resource_tree.json'.format(lang)
+    wrt_filename = 'chefdata/vader/trees/pradigi_{}_web_resource_tree.json'.format(lang)
     with open(wrt_filename) as jsonfile:
         web_resource_tree = json.load(jsonfile)
     # PROCESS
@@ -764,7 +764,7 @@ class PraDigiChef(JsonTreeChef):
         for lang in PRADIGI_WEBSITE_LANGUAGES:
             lang_games = extract_website_games_from_tree(lang)
             website_games[lang] = lang_games
-        WEBSITE_GAMES_OUTPUT = 'chefdata/trees/website_games_all_langs.json'
+        WEBSITE_GAMES_OUTPUT = 'chefdata/vader/trees/website_games_all_langs.json'
         # Save website games
         with open(WEBSITE_GAMES_OUTPUT, 'w') as json_file:
             json.dump(website_games, json_file, ensure_ascii=False, indent=2, sort_keys=True)
@@ -901,7 +901,7 @@ class PraDigiChef(JsonTreeChef):
         LOGGER.info('in pre_run...')
 
         # delete .zip files in temporary dir when running using update
-        if args['update']:
+        if False or args['update']:
             LOGGER.info('Deleting all zips in cache dir {}'.format(HTML5APP_ZIPS_LOCAL_DIR))
             for rel_path in os.listdir(HTML5APP_ZIPS_LOCAL_DIR):
                 abs_path = os.path.join(HTML5APP_ZIPS_LOCAL_DIR, rel_path)
@@ -909,8 +909,8 @@ class PraDigiChef(JsonTreeChef):
                     shutil.rmtree(abs_path)
 
         # option to skip crawling stage
-        if 'nocrawl' not in options:
-            self.crawl(args, options)
+        #if 'nocrawl' not in options:
+            #self.crawl(args, options)
 
         # Conditionally determine `source_id` depending on variant specified
         if 'variant' in options and options['variant'].upper() == 'LE':

--- a/transform.py
+++ b/transform.py
@@ -83,6 +83,8 @@ def get_zip_file(zip_file_url, main_file):
     final_webroot_path = os.path.join(destpath, 'webroot.zip')
     if os.path.exists(final_webroot_path):
         return final_webroot_path
+    else:
+        LOGGER.error("Now we need local files so we can process them: %s" % final_webroot_path)
 
     try:
         download_file(zip_file_url, destpath, request_fn=make_request)
@@ -177,6 +179,18 @@ def get_zip_file(zip_file_url, main_file):
                     bytes_out = bytes_in.replace(main_file.encode('utf-8'), b'index.html')
                     open(file_path, 'wb').write(bytes_out)
 
+        for root, dirs, files in os.walk(zip_folder):
+            for file in files:
+                if file.endswith(".js"):
+                    LOGGER.info("Fixing Android bug in JS file: %s" % file)
+                    with open(file, 'w') as f:
+                        content = f.read()
+                        content = content.replace(
+                            'Utils.mobileDeviceFlag=true', 
+                            'Utils.mobileDeviceFlag=false'
+                        )
+                        f.write(content)
+                        f.close()
         # create the zip file and copy it to 
         tmp_predictable_zip_path = create_predictable_zip(zip_folder)
         shutil.copyfile(tmp_predictable_zip_path, final_webroot_path)


### PR DESCRIPTION
- update paths to use vader-saved json files (the others don't have proper structure)
- comment out / skip crawling and the code that deletes zip files (which should only happen by command but... better safe than sorry I suppose)
- add a log when file not available basically saying "we couldn't find the zip file locally" (example below)

```shell
ERROR    get_zip_file: http://www.prathamopenschool.org/CourseContent/Games/Awazchitra_HI.zip, http://www.prathamopenschool.org/CourseContent/Games/Awazchitra_HI/index.html, chefdata/zipfiles/6026ab9c1e843071fb8b753c0859bd14, HTTPSConnectionPool(host='www.prathamopenschool.org', port=443): Max retries exceeded with url: /CourseContent/Games│
/Awazchitra_HI.zip (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))                                                                                                                                                              
ERROR    Failed to generate node for आवाज़-चितर in hi Could not get zip file from http://www.prathamopenschool.org/CourseContent/Games/Awazchitra_HI.zip                                                                                                                                                                                               
ERROR    Now we need local files so we can process them: chefdata/zipfiles/836b5e1fd2cd81abda92160526581047/webroot.zip 
```

One note is that I don't change the base directory for the zipfiles so just want to be sure they're in `chefdata/zipfiles` when running.